### PR TITLE
Display an error message if release asset cannot be found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,10 @@ if [ -z "$version" ]; then
         command grep -o "/${owner}/${repo}/releases/download/.*/${file_name}" |
         command head -n 1
     )
-    if [[ ! "$asset_path" ]]; then exit 1; fi
+    if [[ ! "$asset_path" ]]; then
+        echo "ERROR: unable to find a release asset called ${file_name}"
+        exit 1
+    fi
     asset_uri="${githubUrl}${asset_path}"
 else
     asset_uri="${githubUrl}/${owner}/${repo}/releases/download/${version}/${file_name}"


### PR DESCRIPTION
The following issue was hard to debug because there was no error message: https://github.com/axetroy/dvm/issues/98

This PR adds an error message to help with debugging future errors :)