### PR TITLE
Use Github API to find asset link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ owner=""
 repo=""
 exe_name=""
 githubUrl=""
+githubApiUrl=""
 version=""
 
 get_arch() {
@@ -94,6 +95,9 @@ fi
 if [ -z "$githubUrl" ]; then
     githubUrl="https://github.com"
 fi
+if [ -z "$githubApiUrl" ]; then
+    githubApiUrl="https://api.github.com"
+fi
 
 downloadFolder="${HOME}/Downloads"
 mkdir -p ${downloadFolder} # make sure download folder exists
@@ -106,7 +110,10 @@ executable_folder="/usr/local/bin" # Eventually, the executable file will be pla
 # if version is empty
 if [ -z "$version" ]; then
     asset_path=$(
-        command curl -sSf ${githubUrl}/${owner}/${repo}/releases |
+        command curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${githubApiUrl}/repos/${owner}/${repo}/releases |
         command grep -o "/${owner}/${repo}/releases/download/.*/${file_name}" |
         command head -n 1
     )


### PR DESCRIPTION
The script currently uses the Github website to determine which release assets are available. Unfortunately, the default view on the website looks like this (example from [dvm](https://github.com/axetroy/dvm/releases/tag/v1.3.11)):

![gh-assets](https://github.com/release-lab/install/assets/20535393/51baeee1-ae32-47c7-8d95-6ee9ae424b33)

To view all assets, you need to click the `Show all 37 assets` link, or wait for JavaScript in your browser to automatically load the extra assets. Both things do not happen when fetching over Curl, which means most of the assets are not available to the installer.

To fix this, I have changed the script to fetch the data from the Github API instead, which is designed for programmatic access. You can read about the API here: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases


Fixes https://github.com/axetroy/dvm/issues/98